### PR TITLE
Remove variables that aren't variable

### DIFF
--- a/book.json
+++ b/book.json
@@ -3,8 +3,7 @@
   "title": "nio documentation",
   "description": "Design complex systems with the simple building blocks of nio.",
   "variables": {
-    "company": "niolabs",
-    "product": "nio"
+    "company": "niolabs"
   },
   "plugins": [
     "theme-nio@git://github.com/niolabs/gitbook-plugin-theme-nio.git",

--- a/book.json
+++ b/book.json
@@ -3,7 +3,6 @@
   "title": "nio documentation",
   "description": "Design complex systems with the simple building blocks of nio.",
   "variables": {
-    "company": "niolabs"
   },
   "plugins": [
     "theme-nio@git://github.com/niolabs/gitbook-plugin-theme-nio.git",

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 Welcome to nio! This documentation strives to help you design complex systems with nio—a distributed orchestration platform.
 
-This is a work in progress and {{ book.company }} welcomes your feedback on the documentation. If you have questions, comments, or suggestions about this document, please email [editor@n.io](mailto:editor@n.io).
+This is a work in progress and niolabs welcomes your feedback on the documentation. If you have questions, comments, or suggestions about this document, please email [editor@n.io](mailto:editor@n.io).
 
 <table border=0 cellpadding=0 cellspacing=0 style="width:100%">
  <tr>

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
-# {{ book.product }} Documentation
+# nio Documentation
 
-Welcome to {{ book.product }}! This documentation strives to help you design complex systems with {{ book.product }}—a distributed orchestration platform.
+Welcome to nio! This documentation strives to help you design complex systems with nio—a distributed orchestration platform.
 
 This is a work in progress and {{ book.company }} welcomes your feedback on the documentation. If you have questions, comments, or suggestions about this document, please email [editor@n.io](mailto:editor@n.io).
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,3 +1,3 @@
-# {{ book.product }} API
+# nio API
 
-The {{ book.product }} API is the mechanism for interacting with a running {{ book.product }} instance and its blocks and services. It follows a simple, RESTful design.
+The nio API is the mechanism for interacting with a running nio instance and its blocks and services. It follows a simple, RESTful design.

--- a/docs/api/additional.md
+++ b/docs/api/additional.md
@@ -1,9 +1,9 @@
 # Additional APIs
 
-{{ book.product }} has  additional APIs that you may find useful as you explore what {{ book.product }} has to offer.
+nio has  additional APIs that you may find useful as you explore what nio has to offer.
 
 ## Configuration Refresh API
 
-The `/config/refresh` endpoint, provided by the `config` component, is used to update a running {{ book.product }} instance when its block or service configuration files were modified through some means other than the `/blocks` and `/services` APIs. For example, if you use a text editor to modify a block configuration file, you need to tell the running {{ book.product }} instance to use those changes. You can do this with a GET request to the `/config/refresh` endpoint of your running instance.
+The `/config/refresh` endpoint, provided by the `config` component, is used to update a running nio instance when its block or service configuration files were modified through some means other than the `/blocks` and `/services` APIs. For example, if you use a text editor to modify a block configuration file, you need to tell the running nio instance to use those changes. You can do this with a GET request to the `/config/refresh` endpoint of your running instance.
 
     curl -XGET 'localhost:8181/config/refresh' --user 'Admin:Admin'

--- a/docs/api/blocks.md
+++ b/docs/api/blocks.md
@@ -1,6 +1,6 @@
 # Blocks API
 
-A configured instance of a {{ book.product }} block type is referred to simply as a block. While block types are classes and have code, blocks are specific configurations of a block type's properties. Earlier we saw an example of a _Logger_ block instance created with the name `Log`. Information about and interaction with individual block configurations in a running {{ book.product }} instance are available through the `/blocks` API.  
+A configured instance of a nio block type is referred to simply as a block. While block types are classes and have code, blocks are specific configurations of a block type's properties. Earlier we saw an example of a _Logger_ block instance created with the name `Log`. Information about and interaction with individual block configurations in a running nio instance are available through the `/blocks` API.  
 
 ## Get API
 
@@ -45,7 +45,7 @@ In addition to getting the details of one block configuration, specified by name
 
 ## Create API
 
-If you're working with a {{ book.product }} project from scratch, you need to create and configure blocks. You can create a new configuration of a block with the Create API by sending a POST request to `/blocks` with the applicable JSON data. When creating a new block configuration, optionally you can include the configured values of the block type's properties. At a minimum, you must specify the block `type`, the `name` of the new configuration, and values for any required properties that do not have a default value. For example, to create a _Logger_ block type with the name `Log`
+If you're working with a nio project from scratch, you need to create and configure blocks. You can create a new configuration of a block with the Create API by sending a POST request to `/blocks` with the applicable JSON data. When creating a new block configuration, optionally you can include the configured values of the block type's properties. At a minimum, you must specify the block `type`, the `name` of the new configuration, and values for any required properties that do not have a default value. For example, to create a _Logger_ block type with the name `Log`
 
     curl -XPOST 'http://localhost:8181/blocks' --data '{"type": "LoggerBlock", "name": "Log"}' -H 'Content-Type: application/json'
 

--- a/docs/api/blocks_types.md
+++ b/docs/api/blocks_types.md
@@ -1,6 +1,6 @@
 # Blocks Types API
 
-{{ book.product }} block types are the functional pieces of code that generate or transform signals. Earlier we saw examples of block types, such as _CounterIntervalSimulator_ and _Logger_. Information about and interaction with the blocks of a running {{ book.product }} instance are available through the `/blocks_types` API.  
+nio block types are the functional pieces of code that generate or transform signals. Earlier we saw examples of block types, such as _CounterIntervalSimulator_ and _Logger_. Information about and interaction with the blocks of a running nio instance are available through the `/blocks_types` API.  
 
 ## Get API
 
@@ -117,7 +117,7 @@ The result of the previous request follows:
 
 **name**<br>The name of the block type.
 
-**version**<br>The version of the block type that is being used by the running {{ book.product }} instance.
+**version**<br>The version of the block type that is being used by the running nio instance.
 
 **namespace**<br>The class the block type is imported from.
 
@@ -145,12 +145,12 @@ In addition to getting the details of one block type, specified by name, you can
 
 ## Add API
 
-When {{ book.product }} starts, it discovers and adds all the block types in the project. If you add a new block type to a running instance of {{ book.product }}, it will not be discovered until nio restarts. However, you can add the new block type to a running instance with the Add API. After the block code is added to the project directory, send a PUT request to the new block type name to load the new block type into the running {{ book.product }} instance
+When nio starts, it discovers and adds all the block types in the project. If you add a new block type to a running instance of nio, it will not be discovered until nio restarts. However, you can add the new block type to a running instance with the Add API. After the block code is added to the project directory, send a PUT request to the new block type name to load the new block type into the running nio instance
 
     curl -XPUT 'http://localhost:8181/blocks_types/<NewBlockTypeName>'
 
 ## Update API
 
-When {{ book.product }} starts, it discovers and adds all the block types in the project. When code in an existing block type is changed in a project (for example, when upgrading to a newer version of the block type) in a running {{ book.product }} instance, you need to tell {{ book.product }} to use the updated code. You can do that with the Update API. Once the new block code is updated in the project directory, send a PUT request to the updated block type to load it into the running {{ book.product }} instance
+When nio starts, it discovers and adds all the block types in the project. When code in an existing block type is changed in a project (for example, when upgrading to a newer version of the block type) in a running nio instance, you need to tell nio to use the updated code. You can do that with the Update API. Once the new block code is updated in the project directory, send a PUT request to the updated block type to load it into the running nio instance
 
     curl -XPUT 'http://localhost:8181/blocks_types/Logger'

--- a/docs/api/conventions.md
+++ b/docs/api/conventions.md
@@ -1,8 +1,8 @@
 # API Conventions
 
-You can interact with most {{ book.product }} binaries through a REST API. The API supports the standard HTTP request types of `GET`, `POST`, `PUT`, and `DELETE`. Data responses are returned in JSON format.
+You can interact with most nio binaries through a REST API. The API supports the standard HTTP request types of `GET`, `POST`, `PUT`, and `DELETE`. Data responses are returned in JSON format.
 
-The REST API is available in {{ book.product }} binaries that include the {{ book.product }} REST Component. Read more about {{ book.product }} core components in [components](../components/README.md).
+The REST API is available in nio binaries that include the nio REST Component. Read more about nio core components in [components](../components/README.md).
 
 ## Authentication and Authorization
 
@@ -10,7 +10,7 @@ Authentication is the action to verify the identity of a user or process.
 
 Authorization is the process of giving someone permission to perform an action.
 
-You will need to include an authorization header with your {{ book.product }} API requests. For examples, see [Basic Auth](#basic-authentication-basic-auth) and [JWT](#json-web-tokens-jwt). For examples of adding headers to cURL requests, see [Headers](#headers).
+You will need to include an authorization header with your nio API requests. For examples, see [Basic Auth](#basic-authentication-basic-auth) and [JWT](#json-web-tokens-jwt). For examples of adding headers to cURL requests, see [Headers](#headers).
 
 User names and passwords are specified in the `users.json` file in the `etc` directory.
 
@@ -34,7 +34,7 @@ You can change the location of your users and permissions files in the `[securit
 
 The default configuration is shown. You can uncomment the default configuration and it will not change. To find your users and permissions in files other than `etc/users.json` and `etc/permissions.json`, uncomment the configuration and edit it.
 
-You can use different types of authentication, such as basic authentication and JSON Web Tokens, with {{ book.product }}.
+You can use different types of authentication, such as basic authentication and JSON Web Tokens, with nio.
 
 ### Basic Authentication (Basic Auth)
 
@@ -56,7 +56,7 @@ For examples of adding headers to a curl request, see [Headers](#headers).
 
 ## Testing with curl
 
-To test {{ book.product }} API requests and responses, you can use a tool such as [Postman](https://www.getpostman.com/) or a curl command from your terminal. curl commands start with `curl`, and then include the request type, a URL, and possibly a request header and a request body. For the {{ book.product }} API, an authorization [header](#headers) is required.
+To test nio API requests and responses, you can use a tool such as [Postman](https://www.getpostman.com/) or a curl command from your terminal. curl commands start with `curl`, and then include the request type, a URL, and possibly a request header and a request body. For the nio API, an authorization [header](#headers) is required.
 
 ### Request Type
 Your request type will be one of `GET`, `POST`, `PUT`, or `DELETE`.
@@ -72,7 +72,7 @@ With the curl command, you can specify with following options:
 Your request type will be followed by a URL.
 
 #### Base URL
-The base of the URL for your API request is the address where your {{ book.product }} project is running. Obtain the base URL from terminal in your nio logs.
+The base of the URL for your API request is the address where your nio project is running. Obtain the base URL from terminal in your nio logs.
 
 For a local project
 
@@ -88,7 +88,7 @@ The endpoint is added to the base URL
 
     http://localhost:8181/blocks_types
 
-You can also add query parameters to the URL, but for the most part, the {{ book.product }} API does not use query parameters.
+You can also add query parameters to the URL, but for the most part, the nio API does not use query parameters.
 
 ### Headers
 
@@ -115,6 +115,6 @@ In the request body, if you need to include data, add body data to a curl reques
 
 ### Putting It All Together
 
-A typical curl request to the {{ book.product }} API incorporating all these parts follows:
+A typical curl request to the nio API incorporating all these parts follows:
 
     curl -XPOST 'http://localhost:8181/blocks' --user 'Admin:Admin' --data '{"type": "LoggerBlock", "name": "Log"}' -H 'Content-Type: application/json'

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -1,10 +1,10 @@
 # Core APIs
 
-{{ book.product }} core has a few crucial API endpoints: `/nio` and `/shutdown`.  
+nio core has a few crucial API endpoints: `/nio` and `/shutdown`.  
 
 ## nio
 
-The `/nio` endpoint is used to find information, such as versioning, about your running {{ book.product }} instances
+The `/nio` endpoint is used to find information, such as versioning, about your running nio instances
 
     curl -XGET 'localhost:8181/nio'
 
@@ -87,14 +87,14 @@ The following JSON body is returned:
 **nio**
   - **binary**<br>The name of the executable binary that was run against the project.
   - **build**<br>The build version of the binary.
-  - **version**<br>The version of the {{ book.product }} framework (not the version of the **binary**).
+  - **version**<br>The version of the nio framework (not the version of the **binary**).
 
-**start_time**<br>A datetime string that indicates when {{ book.product }} was started.
+**start_time**<br>A datetime string that indicates when nio was started.
 
 
 ## Shutdown
 
-The `/shutdown` endpoint is used to shutdown a running {{ book.product }} instance.
+The `/shutdown` endpoint is used to shutdown a running nio instance.
 
     curl -XGET 'http://localhost:8181/shutdown'
 

--- a/docs/api/services.md
+++ b/docs/api/services.md
@@ -1,6 +1,6 @@
 # Services API
 
-Services are the real-time processes that run on an instance in {{ book.product }} where you configure the logic of the workflow of blocks to make interesting things happen. Earlier we created a service called `SimulateAndLog` where we connected a _CounterIntervalSimulator_ to a _Logger_. Information about and interaction with the services of a running {{ book.product }} instance are available through the `/services` API.
+Services are the real-time processes that run on an instance in nio where you configure the logic of the workflow of blocks to make interesting things happen. Earlier we created a service called `SimulateAndLog` where we connected a _CounterIntervalSimulator_ to a _Logger_. Information about and interaction with the services of a running nio instance are available through the `/services` API.
 
 ## Get API
 
@@ -48,7 +48,7 @@ The result of the previous request is
 
   **log_level**<br>The number of log messages displayed, from `NOTSET` on the bottom, which includes all messages logged, to `CRITICAL` on the top, which contains only the most critical messages. Messages are shown for the specified `log_level` and all levels above.
 
-  **auto_start**<br>A boolean that indicates if the service will start when {{ book.product }} starts up.
+  **auto_start**<br>A boolean that indicates if the service will start when nio starts up.
 
   **status**<br>Current status of the service: configuring, configured, starting, started, stopping, stopped, and error.
 
@@ -66,7 +66,7 @@ In addition to getting the details of one service configuration, specified by na
 
 ## Create API
 
-If you're working with a {{ book.product }} project from scratch, you need to create and configure services. Create a new service with the Create API by sending a POST request with the applicable JSON data. When creating a new service, you can optionally include the configured values of the service type properties. At a minimum, you must specify the service `type` and `name` and any configuration values for required service properties that do not have a default value. For example, to create the `SimulateAndLog` service of the basic type `Service`
+If you're working with a nio project from scratch, you need to create and configure services. Create a new service with the Create API by sending a POST request with the applicable JSON data. When creating a new service, you can optionally include the configured values of the service type properties. At a minimum, you must specify the service `type` and `name` and any configuration values for required service properties that do not have a default value. For example, to create the `SimulateAndLog` service of the basic type `Service`
 
     curl -XPOST 'http://localhost:8181/services' --data '{"type": "Service", "name": "SimulateAndLog"}' -H 'Content-Type: applcation/json'
 

--- a/docs/blocks/README.md
+++ b/docs/blocks/README.md
@@ -1,10 +1,10 @@
 # Blocks
 
-Blocks are the units of {{ book.product }} that send, receive, and process signals. What makes a block a block?
+Blocks are the units of nio that send, receive, and process signals. What makes a block a block?
 
 A block has a life cycle and at least one input terminal or one output terminal. Optionally, you can configure properties within the block. A block also has the potential to accept commands from the block REST API.
 
-In summary, a {{ book.product }} block is:
+In summary, a nio block is:
 - A unit of functionality that runs in a service
 - A process that goes through the six stages of the block life cycle: configuring, configured, starting, started, stopping, stopped, (and hopefully not an error)
 - A functional piece of code that receives streaming input signals and/or emits streaming output signals

--- a/docs/blocks/block-development/block-testing.md
+++ b/docs/blocks/block-development/block-testing.md
@@ -1,6 +1,6 @@
 # Testing Your Block
 
-{{ book.product }} blocks are not meant to be run as stand-alone Python modules, so testing can be a challenging process. {{ book.product }} provides a couple of tools and offers best practices to make your testing easier.
+nio blocks are not meant to be run as stand-alone Python modules, so testing can be a challenging process. nio provides a couple of tools and offers best practices to make your testing easier.
 
 ## NIOBlockTestCase
 
@@ -31,7 +31,7 @@ class TestYourBlock(NIOBlockTestCase):
 
 ## setUp/tearDown
 
-Just like the `unittest.TestCase`, {{ book.product }} supports the setUp/tearDown pattern. This is a great place to do any initialization and/or cleanup that will be required across every test. Do not repeat yourself! Be aware, though, that the block provides crucial initialization and finalization in `NIOBlockTestCase.setUp/tearDown`. If you override either of these methods, you need to call the method in the parent class at the top of your method.
+Just like the `unittest.TestCase`, nio supports the setUp/tearDown pattern. This is a great place to do any initialization and/or cleanup that will be required across every test. Do not repeat yourself! Be aware, though, that the block provides crucial initialization and finalization in `NIOBlockTestCase.setUp/tearDown`. If you override either of these methods, you need to call the method in the parent class at the top of your method.
 
 ## Helper Methods
 
@@ -126,9 +126,9 @@ class TestPersistenceBlock(NIOBlockTestCase):
 		 blk.persistence.save = MagicMock()
 ```
 
-## {{ book.product }} Modules
+## nio Modules
 
-`NIOBlockTestCase` configures the following {{ book.product }} modules by default: `['logging', 'scheduler', 'security', 'threading']`. If your block test case needs to use any other {{ book.product }} modules, you must specify by implementing the `get_test_modules` method.
+`NIOBlockTestCase` configures the following nio modules by default: `['logging', 'scheduler', 'security', 'threading']`. If your block test case needs to use any other nio modules, you must specify by implementing the `get_test_modules` method.
 
 If your test case uses persistence, enter the following code:
 

--- a/docs/blocks/block-development/development.md
+++ b/docs/blocks/block-development/development.md
@@ -2,7 +2,7 @@
 
 After cloning the [block template](block-template.md) repository, you are ready to develop your block.
 
-A good resource for new block development is the {{ book.product }} base block along with other blocks that have functionality similar to the one you would like to develop.
+A good resource for new block development is the nio base block along with other blocks that have functionality similar to the one you would like to develop.
 
 The basic elements of a block that you will define are its [properties](#properties), [commands](#commands), and [inputs and outputs](#inputs-and-outputs).
 
@@ -14,7 +14,7 @@ Once you have developed your block, you will want to [test](block-testing.md) an
 
 ## Base Block Class
 
-All {{ book.product }} blocks inherit from the base block class. The first import in the block template's `example_block.py` is `nio.block.base`. If you explore the code inside `nio.block.base`, you'll find explanatory docstrings for each method—including methods to override in your custom block—along with higher-level context.
+All nio blocks inherit from the base block class. The first import in the block template's `example_block.py` is `nio.block.base`. If you explore the code inside `nio.block.base`, you'll find explanatory docstrings for each method—including methods to override in your custom block—along with higher-level context.
 
 An important principle to remember when developing your block is that [signals are passed as lists](/service-design-patterns/understanding-signals.md#lists-of-signals).
 
@@ -31,7 +31,7 @@ The following methods from the base block are designed to be overridden:
   * `process_signals(<list of signals>, input_id)`: receives input signals.
   * `notify_signals(<list of signals>, output_id)`: emits signals from the block. This method isn't intended to be overridden, but should be called by the block to send out signals. For example, you will usually call `notify_signals` at the end of your `process_signals` method.
 
-## Current {{ book.product }} Blocks
+## Current nio Blocks
 
 An additional resource for developing your custom block is the [nio-blocks library](https://github.com/nio-blocks). Search the nio-blocks library for a block that has similar functionality to the block you need. Explore its properties, methods, commands, inputs, outputs, [mixins](mixins.md), and any modules imported from the [framework](framework.md).
 
@@ -68,7 +68,7 @@ Block properties can include the following types:
 
 - **FileProperty**<br>A file stream.
 
-- **ListProperty**<br>List properties hold a list of object types which contain properties themselves or can be {{ book.product }} types such as IntType.
+- **ListProperty**<br>List properties hold a list of object types which contain properties themselves or can be nio types such as IntType.
 
 - **ObjectProperty**<br>Object types contain properties themselves.
 

--- a/docs/blocks/block-development/documenting.md
+++ b/docs/blocks/block-development/documenting.md
@@ -1,6 +1,6 @@
 # Documenting Your Block
 
-There is a standard way to document a {{ book.product }} block. Much of this documentation can be generated automatically using the `nio-cli`.
+There is a standard way to document a nio block. Much of this documentation can be generated automatically using the `nio-cli`.
 
 Once you have built your block, navigate to the root of your project directory and type
 ```

--- a/docs/blocks/block-development/framework.md
+++ b/docs/blocks/block-development/framework.md
@@ -1,6 +1,6 @@
-# The {{ book.product }} Framework
+# The nio Framework
 
-When you develop {{ book.product }} blocks, you use the {{ book.product }} framework. The framework holds all the classes required to create your block as well as the functionality to tie everything together. Think of the framework as a toolshed of useful tools for working with {{ book.product }}.
+When you develop nio blocks, you use the nio framework. The framework holds all the classes required to create your block as well as the functionality to tie everything together. Think of the framework as a toolshed of useful tools for working with nio.
 
 ## Block Context
 

--- a/docs/blocks/properties/README.md
+++ b/docs/blocks/properties/README.md
@@ -41,11 +41,11 @@ In the _Modifier_ block shown above, the `ShowAlertLevel` block is configured so
 
 ## Expressions
 
-Expressions are used to dynamically define properties. Many property types can accept expressions. Expressions are found inside the double curly braces. In the _Dynamic Fields_ block configuration shown above, you can see example expressions in the Attribute Value inputs. Learn more about how to create expressions in [{{ book.product }} Expressions](./expressions.md).
+Expressions are used to dynamically define properties. Many property types can accept expressions. Expressions are found inside the double curly braces. In the _Dynamic Fields_ block configuration shown above, you can see example expressions in the Attribute Value inputs. Learn more about how to create expressions in [nio Expressions](./expressions.md).
 
 ## Environment Variables
 
-Another syntax that {{ book.product }} uses in property configuration is the double-square-bracket notation for an [environment variable](/service-design-patterns/environment-variables.md).
+Another syntax that nio uses in property configuration is the double-square-bracket notation for an [environment variable](/service-design-patterns/environment-variables.md).
 
 `[[YOUR_ENV_VAR]]`
 

--- a/docs/blocks/properties/expressions.md
+++ b/docs/blocks/properties/expressions.md
@@ -1,8 +1,8 @@
-# {{ book.product }} Expressions
+# nio Expressions
 
-An expression is an element of code that needs be evaluated to return a result. You can use {{ book.product }} expressions to dynamically define the value of a property when the signal enters a block. 
+An expression is an element of code that needs be evaluated to return a result. You can use nio expressions to dynamically define the value of a property when the signal enters a block. 
 
-{{ book.product }} expressions are modeled on string interpolation in other dynamic languages. The piece of code between the double curly braces is evaluated as Python code. 
+nio expressions are modeled on string interpolation in other dynamic languages. The piece of code between the double curly braces is evaluated as Python code. 
 ```
 {{ <code goes here> }}
 ```

--- a/docs/components/README.md
+++ b/docs/components/README.md
@@ -1,10 +1,10 @@
 # Core Components
 
-Part of the {{ book.product }} binary consists of core components. These are pieces of functionality that run alongside the {{ book.product }} core process. Unlike modules which run in every {{ book.product }} service, a core component will only be run once and will run in the core/main process.
+Part of the nio binary consists of core components. These are pieces of functionality that run alongside the nio core process. Unlike modules which run in every nio service, a core component will only be run once and will run in the core/main process.
 
 Examples of core components include:  
   * A project manager component that exposes an API to interact with your project contents
-  * A REST component that provides an interface for interacting with {{ book.product }} services and blocks
+  * A REST component that provides an interface for interacting with nio services and blocks
   * An SNMP agent component that exposes runtime information in SNMP form for easy ingestion from monitoring tools
   * A logging component that exposes an API to retrieve an instance's log messages and to change log levels for currently running services, blocks and components
   * A service monitor component that monitors service statuses able to restart a service if it becomes unresponsive

--- a/docs/components/snmp.md
+++ b/docs/components/snmp.md
@@ -1,6 +1,6 @@
 # SNMP Agent Component
 
-The SNMP Agent core component allows you to monitor the health of a {{ book.product }} system through the standard [SNMP protocol](https://en.wikipedia.org/wiki/Simple_Network_Management_Protocol).
+The SNMP Agent core component allows you to monitor the health of a nio system through the standard [SNMP protocol](https://en.wikipedia.org/wiki/Simple_Network_Management_Protocol).
 
 ## Behavior
 

--- a/docs/copyright.md
+++ b/docs/copyright.md
@@ -2,7 +2,7 @@
 
 All Rights Reserved.
 
-{{ book.company }} may have patents, patent applications, trademarks, copyrights, or other intellectual property rights covering subject matter in this documentation. Except as expressly provided in any written license agreement from {{ book.company }}, the furnishing of this documentation does not give you any license to these patents, trademarks, copyrights, or other intellectual property.
+niolabs may have patents, patent applications, trademarks, copyrights, or other intellectual property rights covering subject matter in this documentation. Except as expressly provided in any written license agreement from niolabs, the furnishing of this documentation does not give you any license to these patents, trademarks, copyrights, or other intellectual property.
 
 [nio License for Test Users](https://app.n.io/legal/license)
 

--- a/docs/copyright.md
+++ b/docs/copyright.md
@@ -4,6 +4,6 @@ All Rights Reserved.
 
 {{ book.company }} may have patents, patent applications, trademarks, copyrights, or other intellectual property rights covering subject matter in this documentation. Except as expressly provided in any written license agreement from {{ book.company }}, the furnishing of this documentation does not give you any license to these patents, trademarks, copyrights, or other intellectual property.
 
-[{{ book.product}} License for Test Users](https://app.n.io/legal/license)
+[nio License for Test Users](https://app.n.io/legal/license)
 
 [End User License Agreement](https://niolabs.com/eula/)

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -1,14 +1,14 @@
 # Deployment
 
-Designing a stable {{ book.product }} system means having reliable mechanisms for deployment and maintenance. The deployment of {{ book.product }} systems is very flexible, but there are a few best practices to follow.
+Designing a stable nio system means having reliable mechanisms for deployment and maintenance. The deployment of nio systems is very flexible, but there are a few best practices to follow.
 
 ## Git for Version Control
 
-{{ book.product }} projects can be defined as files in a file system. Git permits you to use a standard version control system to record changes to a project. The [project template repository](https://github.com/niolabs/project_template) provides a good starting point to model how you store a project in a git repository. With git, you can use different branches for development and production.
+nio projects can be defined as files in a file system. Git permits you to use a standard version control system to record changes to a project. The [project template repository](https://github.com/niolabs/project_template) provides a good starting point to model how you store a project in a git repository. With git, you can use different branches for development and production.
 
 ## Different Environments
 
-You should use staging and other test environments to run {{ book.product }} projects outside of production. Using {{ book.product }} environment variable files is a good way to achieve this. For example, your project could have two environment variable files `stage.env` and `prod.env` that define how {{ book.product }} should run in the respective environment. You can run {{ book.product }} using a different environment variable by using the `-e` flag of `nio_run`.
+You should use staging and other test environments to run nio projects outside of production. Using nio environment variable files is a good way to achieve this. For example, your project could have two environment variable files `stage.env` and `prod.env` that define how nio should run in the respective environment. You can run nio using a different environment variable by using the `-e` flag of `nio_run`.
 ```
 nio_run -e stage.env
 ```

--- a/docs/getting_started/README.md
+++ b/docs/getting_started/README.md
@@ -1,10 +1,10 @@
 # Getting Started
 
-{{ book.product }} is a highly-scalable stream processing engine that allows you to asynchronously process streaming data signals and act on them in real time. {{ book.product }} is the brain of your real-time application, particularly systems that require distributed processing.
+nio is a highly-scalable stream processing engine that allows you to asynchronously process streaming data signals and act on them in real time. nio is the brain of your real-time application, particularly systems that require distributed processing.
 
-Here are a few sample use cases for {{ book.product }}:
+Here are a few sample use cases for nio:
 
 * You want to know what people are posting about your company on Twitter. You can instantaneously receive notifications when tweets mention your business, automate responses, and identify trends are received. You can even alert your support team when the number of "help me" tweets passes your acceptable threshold.
-* You run a factory and want to measure equipment performance and maintenance factors. To optimize the business processes and reduce downtime,  {{ book.product }} can read the signal from any sensor and act on the data in real time.
+* You run a factory and want to measure equipment performance and maintenance factors. To optimize the business processes and reduce downtime,  nio can read the signal from any sensor and act on the data in real time.
 
-In this getting started tutorial you will learn how to get {{ book.product }} up and running before you proceed to the tutorials.
+In this getting started tutorial you will learn how to get nio up and running before you proceed to the tutorials.

--- a/docs/getting_started/first_service.md
+++ b/docs/getting_started/first_service.md
@@ -3,7 +3,7 @@
 Ready to jump in and start creating the next new thing? Head over to the tutorial site at https://workshops.n.io/ and start the [Hello nio!](https://workshops.n.io/nio-101/hello_nio/) tutorial.
 
 <!--
-# Building Your First {{ book.product }} Service
+# Building Your First nio Service
 
 In the System Designer, you begin with an empty canvas full of possibilities, but there are no services yet. While it won't get too exciting quite yet, you can start by building a very basic service to simulate and log signals.
 
@@ -85,5 +85,5 @@ To command a block:
 
 ## Conclusion
 
-At this point you should feel comfortable installing {{ book.product }}, creating a project with blocks, and configuring and running services. You can find block documentation in the [Block Library at blocks.n.io](https://blocks.n.io/).
+At this point you should feel comfortable installing nio, creating a project with blocks, and configuring and running services. You can find block documentation in the [Block Library at blocks.n.io](https://blocks.n.io/).
 -->

--- a/docs/getting_started/in_the_cloud.md
+++ b/docs/getting_started/in_the_cloud.md
@@ -1,6 +1,6 @@
-# Running {{ book.product }} in the Cloud
+# Running nio in the Cloud
 
-The easiest way to run {{ book.product }} is by running it in the cloud.
+The easiest way to run nio is by running it in the cloud.
 
 Below you can walk through the foundational steps of building a project including creating a system, cloud instance, and service, followed by adding blocks.
 
@@ -40,7 +40,7 @@ Below you can walk through the foundational steps of building a project includin
 ## Add Blocks
 You now have an empty canvas, and now you are ready for blocks.
 
-nio blocks are installed to instances using the Block Library. The collection of blocks created by {{ book.product }} is also stored in the [Block Library at blocks.n.io](https://blocks.n.io/). You can search for blocks in the System Designer or in the Block Library.
+nio blocks are installed to instances using the Block Library. The collection of blocks created by nio is also stored in the [Block Library at blocks.n.io](https://blocks.n.io/). You can search for blocks in the System Designer or in the Block Library.
 
 1. Select the service by clicking the service name under the instance name in the left navigation panel or on the breadcrumb above the contextual toolbar.
 1. In the **Block library** search box, enter a search term.
@@ -50,7 +50,7 @@ nio blocks are installed to instances using the Block Library. The collection of
 1. Name the block.
 1. Click **Accept**.
 
-Once you have {{ book.product }} running, you can create many different projects. To guide you through the process, view the tutorials at https://workshops.n.io/.
+Once you have nio running, you can create many different projects. To guide you through the process, view the tutorials at https://workshops.n.io/.
 
 <!--
 ## Add a Cloud Instance
@@ -81,7 +81,7 @@ To add a service:
 
 You now have an empty canvas, and now you are ready for blocks.
 
-nio blocks are installed to instances using the Block Library. The collection of blocks created by {{ book.product }} is also stored in the [Block Library at blocks.n.io](https://blocks.n.io/). You can search for blocks in the System Designer or in the Block Library.
+nio blocks are installed to instances using the Block Library. The collection of blocks created by nio is also stored in the [Block Library at blocks.n.io](https://blocks.n.io/). You can search for blocks in the System Designer or in the Block Library.
 
 To add a block:
 

--- a/docs/getting_started/locally.md
+++ b/docs/getting_started/locally.md
@@ -1,55 +1,55 @@
-# Running {{ book.product}} Locally
+# Running nio Locally
 
-The cloud is an easy way to get {{ book.product}} up and running, but doesn't fully encapsulate the distributed power of the {{ book.product}} platform. Instead, you should run {{ book.product}} on a local or edge node.  In this guide, you will create a local instance that uses a cloud-based Pubkeeper server to handle communications.
+The cloud is an easy way to get nio up and running, but doesn't fully encapsulate the distributed power of the nio platform. Instead, you should run nio on a local or edge node.  In this guide, you will create a local instance that uses a cloud-based Pubkeeper server to handle communications.
 
-Running the {{ book.product}} platform requires Python version 3.4 or greater.
+Running the nio platform requires Python version 3.4 or greater.
 
 Requirements
 
 * Download Python 3.4 or greater from [https://www.python.org/downloads/](https://www.python.org/downloads/).
-* Obtain the {{ book.product}} binary Python wheel file (`.whl`) with your license agreement.
+* Obtain the nio binary Python wheel file (`.whl`) with your license agreement.
 
-## Download {{ book.product}}
+## Download nio
 
-Download {{ book.product}} from the following URL:
+Download nio from the following URL:
 
 https://app.n.io/binaries/download
 
-## Install the {{ book.product}} binary and CLI
+## Install the nio binary and CLI
 
-To install {{ book.product}}, enter the following command:
+To install nio, enter the following command:
 ```
 pip3 install your_wheel_file.whl
 ```
 
-To install the {{ book.product}} Command Line Interface \(CLI\), enter the following command:
+To install the nio Command Line Interface \(CLI\), enter the following command:
 ```
 pip3 install nio-cli
 ```
 
-## Upgrade the {{ book.product}} binary and CLI
+## Upgrade the nio binary and CLI
 
-To upgrade {{ book.product}}, enter the following command:
+To upgrade nio, enter the following command:
 ```
 pip3 install -U your_wheel_file.whl
 ```
 
-To upgrade the {{ book.product}} Command Line Interface \(CLI\), enter the following command:
+To upgrade the nio Command Line Interface \(CLI\), enter the following command:
 ```
 pip3 install -U nio-cli
 ```
 
 ## Create a Project
 
-Now that you have the {{ book.product}} binary to run, you need a {{ book.product}} project to run it against. Obtain a {{ book.product}} project template by cloning the [Project Template repository](https://github.com/niolabs/project_template) or use the {{ book.product}} CLI.
+Now that you have the nio binary to run, you need a nio project to run it against. Obtain a nio project template by cloning the [Project Template repository](https://github.com/niolabs/project_template) or use the nio CLI.
 
 
-### Download using the {{book.product}} CLI
+### Download using the nio CLI
 To clone the project template using CLI, enter the following command:
 
 `nio new first_project`
 
-The `first_project` directory is created in your working directory containing the {{ book.product}} project.
+The `first_project` directory is created in your working directory containing the nio project.
 
 ### Download using git
 To clone the project template using git, clone the template, and initialize the submodules which contain the blocks.
@@ -59,7 +59,7 @@ cd first_project
 git submodule update --init --recursive
 ```
 
-## Set up {{book.product}} environment
+## Set up nio environment
 
 After adding the new project, change to the project directory
 ```
@@ -92,7 +92,7 @@ WS_PORT: 443
 WS_SECURE: True
 ```
 
-1. To run {{ book.product}}, enter the following command:
+1. To run nio, enter the following command:
 ```
 nio_run
 ```
@@ -115,11 +115,11 @@ nio_run
   [2016-03-04 23:49:41.227] NIO [INFO] [main.ServiceManager] Component: ServiceManager status changed from: starting to: started
   ```
 
-If you see those logs, {{ book.product}} is up and running. Congratulations!
+If you see those logs, nio is up and running. Congratulations!
 
 ## Add a Local Instance
 
-Once you have a local instance running, you can edit it using the System Designer. Based on the log messages, your {{ book.product}} instance is available at `http://localhost:8181` and you need basic authentication to communicate with the instance.
+Once you have a local instance running, you can edit it using the System Designer. Based on the log messages, your nio instance is available at `http://localhost:8181` and you need basic authentication to communicate with the instance.
 
 1. Select the name of your system in the left navigation panel or on the breadcrumb above the contextual toolbar.
 
@@ -134,11 +134,11 @@ Once you have a local instance running, you can edit it using the System Designe
 1. Click **Accept**.
 1. Wait for the instance to spin-up and note the name of the new instance on the left.
 
-Note: When you connect to a {{ book.product}} instance, you are communicating with that instance directly from your browser via an XHR request. Hostnames like `localhost` and other internal IP addresses will work. You must have access to the localhost or other IP address from your machine to use the System Designer.
+Note: When you connect to a nio instance, you are communicating with that instance directly from your browser via an XHR request. Hostnames like `localhost` and other internal IP addresses will work. You must have access to the localhost or other IP address from your machine to use the System Designer.
 
-You may see an issue regarding HTTPS and HTTP instances. Since you launched your instance and presumably didn't load any SSL certificates, the instance is accessible only by HTTP. However, if you are logged into the System Designer via HTTPS, then an XHR request going over HTTP is not permitted due to a browser restriction. Instead, log into the designer via HTTP. All of your instances and systems will be the same, except the {{ book.product}} commands to edit these instances won't happen over HTTPS.
+You may see an issue regarding HTTPS and HTTP instances. Since you launched your instance and presumably didn't load any SSL certificates, the instance is accessible only by HTTP. However, if you are logged into the System Designer via HTTPS, then an XHR request going over HTTP is not permitted due to a browser restriction. Instead, log into the designer via HTTP. All of your instances and systems will be the same, except the nio commands to edit these instances won't happen over HTTPS.
 
-Once your instance is loaded and available, you can add services and blocks in the same manner as the cloud instance. Any errors or activity are available in the logs in your terminal that is running {{ book.product}}. When you need to debug a system, a local instance is a useful tool.
+Once your instance is loaded and available, you can add services and blocks in the same manner as the cloud instance. Any errors or activity are available in the logs in your terminal that is running nio. When you need to debug a system, a local instance is a useful tool.
 
 ## Create a Service
 
@@ -154,7 +154,7 @@ Once your instance is loaded and available, you can add services and blocks in t
 ## Add Blocks
 Before you move on, you're going to want to add some blocks to your project. Blocks can be added in the System Designer or from the command line.
 
-nio blocks are installed to instances using the Block Library. The collection of blocks created by {{ book.product }} is also stored in the [Block Library at blocks.n.io](https://blocks.n.io/). You can search for blocks in the System Designer or in the Block Library.
+nio blocks are installed to instances using the Block Library. The collection of blocks created by nio is also stored in the [Block Library at blocks.n.io](https://blocks.n.io/). You can search for blocks in the System Designer or in the Block Library.
 
 ###To add a block in the System Designer:
 1. Select the service by clicking the service name under the instance name in the left navigation panel or on the breadcrumb above the contextual toolbar.
@@ -178,4 +178,4 @@ This can also be done with the nio-cli with `nio add logger`.
 1. Drag the your block onto the canvas.
 1. Type the name of the block and click **Accept**.
 
-Once you have {{ book.product }} running, you can create many different projects. To guide you through the process, view the tutorials at https://workshops.n.io/.
+Once you have nio running, you can create many different projects. To guide you through the process, view the tutorials at https://workshops.n.io/.

--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -1,19 +1,19 @@
 # Glossary of Terms
 
 ## Binary
-A binary is the executable program that you run to run {{ book.product }}. Depending on your circumstances, you will run one of many {{ book.product }} binaries. Binaries range in complexity and are often tuned for particular hardware. If you're tinkering around on a Raspberry Pi, you don't need to run the same binary as a network of a dozen supercomputers built to analyze hundreds of thousands signals per second.
+A binary is the executable program that you run to run nio. Depending on your circumstances, you will run one of many nio binaries. Binaries range in complexity and are often tuned for particular hardware. If you're tinkering around on a Raspberry Pi, you don't need to run the same binary as a network of a dozen supercomputers built to analyze hundreds of thousands signals per second.
 
 ## Block
 A block is a class that is built off of the Block Development Framework that defines methods to operate on streams of data. A block receives, emits, and/or transforms signals. Blocks are written in Python and tend to focus on one particular function. Blocks are reusable in any other services so it is beneficial to keep them modular.
 
 ## Framework
-The Block Development Framework is the layered structure that defines how to develop blocks. This {{ book.product }} framework consists of the agreed upon interfaces that blocks and binaries understand. Install the framework with pip: `pip install nio`.
+The Block Development Framework is the layered structure that defines how to develop blocks. This nio framework consists of the agreed upon interfaces that blocks and binaries understand. Install the framework with pip: `pip install nio`.
 
 ## Instance
-A running version of the {{ book.product }} back end platform. Each host in a system will likely have at least one {{ book.product }} instance running on it.
+A running version of the nio back end platform. Each host in a system will likely have at least one nio instance running on it.
 
 ## Project
-A {{ book.product }} project is stored in a directory on your computer that contains the configuration that defines your {{ book.product }} implementation. Projects can run on their own or can be a part of a larger {{ book.product }} network where many instances communicate with one another.
+A nio project is stored in a directory on your computer that contains the configuration that defines your nio implementation. Projects can run on their own or can be a part of a larger nio network where many instances communicate with one another.
 
 ## Pubkeeper
 Pubkeeper™ is a communications broker that enables real-time data transfer between a system of disparate devices through standard publish-subscribe patterns. With Pubkeeper, two devices can interact with each other even if they do not share the same communication protocol.
@@ -25,4 +25,4 @@ A service is a real-time process that runs on an instance. The logic is configur
 A signal is a unit of data that is passed from block to block within a service or between services. You can think of it as a little box of data, containing any data from a temperature reading to a tweet. It is internally represented as a key-value store.
 
 ## System
-A system is a distributed set of entities that work together as a whole. For {{ book.product }}, this means a collection of {{ book.product }} back end instances and front end user interfaces that can communicate with one another in real time.
+A system is a distributed set of entities that work together as a whole. For nio, this means a collection of nio back end instances and front end user interfaces that can communicate with one another in real time.

--- a/docs/service-design-patterns/README.md
+++ b/docs/service-design-patterns/README.md
@@ -1,3 +1,3 @@
 # Service Design Patterns
 
-You define the logic of your entire system by designing services and configuring and connecting blocks. The {{ book.product }} service design language is very flexible and allows you to design services in many different ways. However, it is often helpful to follow the suggested patterns in this section of the documentation.
+You define the logic of your entire system by designing services and configuring and connecting blocks. The nio service design language is very flexible and allows you to design services in many different ways. However, it is often helpful to follow the suggested patterns in this section of the documentation.

--- a/docs/service-design-patterns/environment-variables.md
+++ b/docs/service-design-patterns/environment-variables.md
@@ -1,6 +1,6 @@
 # Environment Variables
 
-{{ book.product }} allows you to define and use variables when configuring your instance, services, or blocks. These variables are called "environment variables" and are specified using the square bracket syntax: `[[ ENV_VAR_NAME ]]`. There are several different use cases for environment variables which are detailed below.
+nio allows you to define and use variables when configuring your instance, services, or blocks. These variables are called "environment variables" and are specified using the square bracket syntax: `[[ ENV_VAR_NAME ]]`. There are several different use cases for environment variables which are detailed below.
 
 ## Access Tokens and Other Secrets
 
@@ -13,7 +13,7 @@ Then, in your block config you can use that secret token by using the environmen
 
 ## Different Environments
 
-A large-scale {{ book.product }} system will generally run in multiple environments. Here are several examples:
+A large-scale nio system will generally run in multiple environments. Here are several examples:
 
 1. A multi-tenant setup where the same project runs in many different locations. For example, a smart retail store system where the project runs in every store.
 2. A staging environment used for validation and testing.
@@ -33,13 +33,13 @@ DB_HOST: localhost
 DB_PASS: password
 ```
 
-In your blocks and services, you can use `[[ DB_HOST ]]` as the database host and be assured that when you are running {{ book.product }} locally you aren't talking to the production database.
+In your blocks and services, you can use `[[ DB_HOST ]]` as the database host and be assured that when you are running nio locally you aren't talking to the production database.
 
 See the [Deployment](/deployment) section for more information.
 
 ## Setting Environment Variables
 
-{{ book.product }} environment variables are slightly different than operating system environment variables. {{ book.product }} environment variables can also be set by operation system environment variables. This can be useful when running {{ book.product }} using Docker, systemd, or some other process manager where you can pass environment variables to the process.
+nio environment variables are slightly different than operating system environment variables. nio environment variables can also be set by operation system environment variables. This can be useful when running nio using Docker, systemd, or some other process manager where you can pass environment variables to the process.
 
 In general, environment variables can be sourced from two places.
 

--- a/docs/service-design-patterns/pub-sub.md
+++ b/docs/service-design-patterns/pub-sub.md
@@ -1,6 +1,6 @@
 # Publishing and Subscribing to Data
 
-Designing systems with {{ book.product }} includes designing how information, or signals,  moves through the system. {{ book.product }} recommends using the Pub/Sub mechanisms to move data from one service to another.
+Designing systems with nio includes designing how information, or signals,  moves through the system. nio recommends using the Pub/Sub mechanisms to move data from one service to another.
 The following communication blocks are located at [blocks.n.io](https://blocks.n.io/):
 * [Publisher](https://blocks.n.io/Publisher)
 * [Subscriber](https://blocks.n.io/Subscriber)
@@ -8,7 +8,7 @@ The following communication blocks are located at [blocks.n.io](https://blocks.n
 
 ## Topic Tree
 
-When using the `Publisher` and `Subscriber` blocks, you need to decide which topic you wish to publish to or subscribe to. The information organization of an entire {{ book.product }} system can be viewed as a hierarchical topic tree.
+When using the `Publisher` and `Subscriber` blocks, you need to decide which topic you wish to publish to or subscribe to. The information organization of an entire nio system can be viewed as a hierarchical topic tree.
 
 ### Publishers
 
@@ -64,8 +64,8 @@ Subscribers can subscribe to a single topic or also portions of the topic tree t
 
 <!-- ## Pubkeeper
 
-Perhaps the most impactful reason to use the {{ book.product }} pub/sub system is because of the interoperability enabled through the use of [Pubkeeper](https://pubkeeper.com). Pubkeeper allows us to separate our information hierarchy, or topic tree, from the underlying protocols that will be responsible for transmitting data between services and instances. In other words, it allows service designers to define what data goes to which services without worrying about how it will get there. -->
+Perhaps the most impactful reason to use the nio pub/sub system is because of the interoperability enabled through the use of [Pubkeeper](https://pubkeeper.com). Pubkeeper allows us to separate our information hierarchy, or topic tree, from the underlying protocols that will be responsible for transmitting data between services and instances. In other words, it allows service designers to define what data goes to which services without worrying about how it will get there. -->
 
 ## Hints in the System Designer
 
-One of the benefits of using the {{ book.product }} pub/sub mechanism is that the System Designer understands the topic tree as well. If your service has a `Publisher` or `Subscriber` block with a topic, the designer can show you services that either subscribe to or publish to that topic, respectively. It also permits the System Designer to draw the graph relationship between services and instances.
+One of the benefits of using the nio pub/sub mechanism is that the System Designer understands the topic tree as well. If your service has a `Publisher` or `Subscriber` block with a topic, the designer can show you services that either subscribe to or publish to that topic, respectively. It also permits the System Designer to draw the graph relationship between services and instances.

--- a/docs/service-design-patterns/simulators.md
+++ b/docs/service-design-patterns/simulators.md
@@ -1,6 +1,6 @@
 # Simulators
 
-Most of the time the first service you build with {{ book.product }} involves simulating signals using a `Simulator` block and then logging that data using a `Logger` block. That is the "Hello, World" service of {{ book.product }}. However, simulators are much more powerful and do much more than generate random data. This document attempts to define and explain other use cases for simulators.
+Most of the time the first service you build with nio involves simulating signals using a `Simulator` block and then logging that data using a `Logger` block. That is the "Hello, World" service of nio. However, simulators are much more powerful and do much more than generate random data. This document attempts to define and explain other use cases for simulators.
 
 ## Understanding Simulators
 
@@ -22,7 +22,7 @@ Generators define the shape and contents of the signals that are notified.
 
 ## Driving Another Block
 
-The general design of {{ book.product }} is that **signals** represent data and information and **blocks** represent functions and transformations. However, blocks need to know when and how to perform these functions. Some blocks may need to do an action periodically while others may need to wait for some external action, such as a button press. Rather than trying to define that logic in the block's configuration, you can use incoming signals to trigger the action instead. This also allows the block to "tap in to" the incoming signals and perhaps change its behavior based on the content of the signals. For example, rather than making a fixed HTTP request every interval, a block could send the contents of the incoming signal as part of the HTTP payload instead.
+The general design of nio is that **signals** represent data and information and **blocks** represent functions and transformations. However, blocks need to know when and how to perform these functions. Some blocks may need to do an action periodically while others may need to wait for some external action, such as a button press. Rather than trying to define that logic in the block's configuration, you can use incoming signals to trigger the action instead. This also allows the block to "tap in to" the incoming signals and perhaps change its behavior based on the content of the signals. For example, rather than making a fixed HTTP request every interval, a block could send the contents of the incoming signal as part of the HTTP payload instead.
 
 In some cases, you will not care about the contents of the incoming signal, but want to perform an action. For example, if you wanted to poll the Twitter API every five minutes for new tweets, you would need an incoming signal to the Twitter block when you wanted to poll. Since you don't care about the contents of the signal, any signal, even an empty signal, would suffice. You could use the `IdentityIntervalSimulator` to create such a signal and drive the polling of the Twitter block. The `Identity` generator could be used since we only need an empty signal. The `Interval` trigger could be used to poll the API periodically.
 
@@ -32,7 +32,7 @@ Because of the way we use simulators to kick off the actions of a service, almos
 
 To test a service, you may want data that looks like an actual signal, but do not want to connect to a real data source. To do this, you can create a custom generator for your data format, and then use a simulator block with that generator. The process of creating a custom generator requires writing python code and is documented in more detail in the [signal generator / simulator readme files] https://blocks.n.io/?category=Signal%20Generator).
 
-You can create custom simulated data without writing any code, but this is not as flexible. By pairing a simulator with the `Identity` trigger with a `Modifier` block, a service builder can generate empty signals on a schedule and then route the empty signal to a `Modifier` block where it fills in the information that the signal should consist of. A service building expert would make use of the `random` module inside of a {{ book.product }} expression to generate random data. For example, to generate a signal with a random number from 1 to 10 each time, connect the output of an `IdentityIntervalSimulator` block to a `Modifier` block.
+You can create custom simulated data without writing any code, but this is not as flexible. By pairing a simulator with the `Identity` trigger with a `Modifier` block, a service builder can generate empty signals on a schedule and then route the empty signal to a `Modifier` block where it fills in the information that the signal should consist of. A service building expert would make use of the `random` module inside of a nio expression to generate random data. For example, to generate a signal with a random number from 1 to 10 each time, connect the output of an `IdentityIntervalSimulator` block to a `Modifier` block.
 ```
 {
   "name": "Random Number",

--- a/docs/service-design-patterns/understanding-signals.md
+++ b/docs/service-design-patterns/understanding-signals.md
@@ -1,6 +1,6 @@
 # Understanding Signals
 
-Signals are the pieces of information that are passed from block to block throughout your system. They are the fundamental messages type that {{ book.product }} understands. Structurally, signals are key-value objects.
+Signals are the pieces of information that are passed from block to block throughout your system. They are the fundamental messages type that nio understands. Structurally, signals are key-value objects.
 ```
 {
   "name": "John Doe",
@@ -144,4 +144,4 @@ You added an attribute to your block configuration indentifying the value to gro
 ]
 ```
 
-Understanding how Group By works and when to use it can save a lot of headaches and repetition in {{ book.product }} services allowing you to build very powerful services without many blocks. In general, if you are frequently repeating the same blocks when designing in {{ book.product }}, there is probably a more efficient way to perform the task.
+Understanding how Group By works and when to use it can save a lot of headaches and repetition in nio services allowing you to build very powerful services without many blocks. In general, if you are frequently repeating the same blocks when designing in nio, there is probably a more efficient way to perform the task.

--- a/docs/service-testing/README.md
+++ b/docs/service-testing/README.md
@@ -7,7 +7,7 @@ Use the the [Service Unit Test Framework](https://github.com/niolabs/service_tes
 If you installed the [project template](https://github.com/niolabs/project_template) from the repository, then you are ready. If not, complete the following steps:
 
 1. Install the `jsonschema` Python package. This allows you to validate publishers and subscribers in services.
-2. Clone the [{{ book.product }} Service Units Test](https://github.com/niolabs/service_tests) repository into your project directory as a submodule.
+2. Clone the [nio Service Units Test](https://github.com/niolabs/service_tests) repository into your project directory as a submodule.
 3. Create a `tests` directory to store your own custom service unit tests.
 4. Set up a test class based on the [Service Unit Test](https://github.com/niolabs/service_tests) readme file.
 4. Execute the service tests using a Python test runner.

--- a/docs/support/README.md
+++ b/docs/support/README.md
@@ -2,7 +2,7 @@
 
 We understand that designing distributed systems isn't always easy. That's why {{ book.company }} is here to help!
 
-Choose one of the options below to reach out to the {{ book.product }} support community:
+Choose one of the options below to reach out to the nio support community:
 
 * Live chat from the System Designer - Click the blue conversation bubble in the System Designer to be connected to a live {{ book.company }} support representative. If no one is online, we will still see your message and contact you as soon as we can.
 * Support email - Email [support@n.io](mailto:n.io) any time with any questions or requests.

--- a/docs/support/README.md
+++ b/docs/support/README.md
@@ -1,9 +1,9 @@
 # Support
 
-We understand that designing distributed systems isn't always easy. That's why {{ book.company }} is here to help!
+We understand that designing distributed systems isn't always easy. That's why niolabs is here to help!
 
 Choose one of the options below to reach out to the nio support community:
 
-* Live chat from the System Designer - Click the blue conversation bubble in the System Designer to be connected to a live {{ book.company }} support representative. If no one is online, we will still see your message and contact you as soon as we can.
+* Live chat from the System Designer - Click the blue conversation bubble in the System Designer to be connected to a live niolabs support representative. If no one is online, we will still see your message and contact you as soon as we can.
 * Support email - Email [support@n.io](mailto:n.io) any time with any questions or requests.
 * Community support forums - Coming soon!

--- a/docs/system-designer/README.md
+++ b/docs/system-designer/README.md
@@ -1,6 +1,6 @@
 # System Designer Overview
 
-The System Designer is the graphical user interface used to build your {{ book.product }} system. This overview provides you with a quick tour of the user interface including the navigation, work areas, and toolbars.
+The System Designer is the graphical user interface used to build your nio system. This overview provides you with a quick tour of the user interface including the navigation, work areas, and toolbars.
 
 Note that your screen may look slightly different than the images in the document and video.
 

--- a/docs/system-designer/designer-tasks-old.md
+++ b/docs/system-designer/designer-tasks-old.md
@@ -1,6 +1,6 @@
 # System Designer Basics
 
-The System Designer is the graphical user interface used to build your {{ book.product }} system. This overview provides you with a quick tour of the basics of creating a system, instance, service, and block.
+The System Designer is the graphical user interface used to build your nio system. This overview provides you with a quick tour of the basics of creating a system, instance, service, and block.
 
 ## Systems
 A system is a distributed set of entities that work together as a whole. For nio, this means a collection of nio back end instances and front end user interfaces that can communicate with one another in real time.
@@ -8,7 +8,7 @@ A system is a distributed set of entities that work together as a whole. For nio
 ### Create a System
 
 1. You can create a new system in two ways.
-  * If this is your first time opening {{ book.product}}, the **Create new system** window displays.
+  * If this is your first time opening nio, the **Create new system** window displays.
 
     %accordion%**Click arrow to expand image**%accordion%
 
@@ -16,7 +16,7 @@ A system is a distributed set of entities that work together as a whole. For nio
 
     %/accordion%
 
-  * If you have already been working in {{ book.product}}, in the lower-left corner, click the **`+`** button.
+  * If you have already been working in nio, in the lower-left corner, click the **`+`** button.
 
     %accordion%**Click arrow to expand image**%accordion%
 
@@ -134,7 +134,7 @@ A system is a distributed set of entities that work together as a whole. For nio
   >![](/img/Toolbar-Service.gif)
 1. Click **Auto-Start Off** in the toolbar.
 
-  By default, services are set to auto-start when a {{ book.product }} instance is started.
+  By default, services are set to auto-start when a nio instance is started.
 1. Optional. Click **Edit** in the toolbar, select one of the colored circles to represent this service, and click **Accept**.
 
   By default, the color of a service is white. Color coding your services can help you keep your instances organized when working on larger projects with multiple instances.

--- a/docs/system-designer/designer-tasks.md
+++ b/docs/system-designer/designer-tasks.md
@@ -1,6 +1,6 @@
 # System Designer Basics
 
-The System Designer is the graphical user interface used to build your {{ book.product }} system. This overview provides you with a quick tour of the basics of creating a system, instance, service, and block.
+The System Designer is the graphical user interface used to build your nio system. This overview provides you with a quick tour of the basics of creating a system, instance, service, and block.
 
 
 ## Get Help
@@ -21,7 +21,7 @@ The System Designer is the graphical user interface used to build your {{ book.p
 ### Create a System
 
 1. You can create a new system in two ways.
-  * If this is your first time opening {{ book.product}}, the **Create new system** window displays.
+  * If this is your first time opening nio, the **Create new system** window displays.
 
     %accordion%**Click arrow to expand image**%accordion%
 
@@ -29,7 +29,7 @@ The System Designer is the graphical user interface used to build your {{ book.p
 
     %/accordion%
 
-  * If you have already been working in {{ book.product}}, in the lower-left corner, click the **`+`** button.
+  * If you have already been working in nio, in the lower-left corner, click the **`+`** button.
 
     %accordion%**Click arrow to expand image**%accordion%
 
@@ -147,7 +147,7 @@ The System Designer is the graphical user interface used to build your {{ book.p
   >![](/img/Toolbar-Service.gif)
 1. Click **Auto-Start Off** in the toolbar.
 
-  By default, services are set to auto-start when a {{ book.product }} instance is started.
+  By default, services are set to auto-start when a nio instance is started.
 1. Optional. Click **Edit** in the toolbar, select one of the colored circles to represent this service, and click **Accept**.
 
   By default, the color of a service is white. Color coding your services can help you keep your instances organized when working on larger projects with multiple instances.


### PR DESCRIPTION
We don't plan on changing the company or product name anytime soon, and the
variables make searching and contributing difficult.

Here are the commands that were run:
```
find docs -type f -regex .*.md -exec sed -i '' -E "s/{{[ ]?book.product[ ]?}}/nio/g" {} +
find docs -type f -regex .*.md -exec sed -i '' -E "s/{{[ ]?book.company[ ]?}}/niolabs/g" {} +
```