### PR TITLE
Update the license route

### DIFF
--- a/docs/copyright.md
+++ b/docs/copyright.md
@@ -4,6 +4,6 @@ All Rights Reserved.
 
 niolabs may have patents, patent applications, trademarks, copyrights, or other intellectual property rights covering subject matter in this documentation. Except as expressly provided in any written license agreement from niolabs, the furnishing of this documentation does not give you any license to these patents, trademarks, copyrights, or other intellectual property.
 
-[nio License for Test Users](https://app.n.io/legal/license)
+[nio License for Test Users](https://app.n.io/legal/license/beta)
 
 [End User License Agreement](https://niolabs.com/eula/)


### PR DESCRIPTION
The beta license route changed to `https://app.n.io/legal/license/beta`