### PR TITLE
nio_run -> niod

### DIFF
--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -8,9 +8,9 @@ nio projects can be defined as files in a file system. Git permits you to use a 
 
 ## Different Environments
 
-You should use staging and other test environments to run nio projects outside of production. Using nio environment variable files is a good way to achieve this. For example, your project could have two environment variable files `stage.env` and `prod.env` that define how nio should run in the respective environment. You can run nio using a different environment variable by using the `-e` flag of `nio_run`.
+You should use staging and other test environments to run nio projects outside of production. Using nio environment variable files is a good way to achieve this. For example, your project could have two environment variable files `stage.env` and `prod.env` that define how nio should run in the respective environment. You can run nio using a different environment variable by using the `-e` flag of `niod`.
 ```
-nio_run -e stage.env
+niod -e stage.env
 ```
 
 Sometimes, it doesn't make sense to run an individual service in a non-production environment. To achieve this, create an environment variable such as `SHOULD_RUN_SERVICE` and set it to `yes` or `no` depending on the environment. Then, you can set the service's auto start value in the service configuration to the result of the variable.

--- a/docs/getting-started/locally.md
+++ b/docs/getting-started/locally.md
@@ -82,7 +82,7 @@ With your system selected, click **edit** in the contextual toolbar to open the 
 
 With your project installed and Pubkeeper communication configured, you are ready to run your nio binary. In your terminal, from the root of your project directory, enter the following command:
 ```
-nio_run
+niod
 ```
 > If that command is not available, make sure your Python binary installation directory is on your PATH.
 

--- a/docs/services/service-design-patterns/environment-variables.md
+++ b/docs/services/service-design-patterns/environment-variables.md
@@ -47,17 +47,17 @@ In general, environment variables can be sourced from two places.
 
    ```bash
    $ export DB_HOST=localhost
-   $ nio_run
+   $ niod
    ```
 
    ```bash
    $ docker run -e DB_HOST=localhost nio_binary_image
    ```
 
-2. The `.env` files in your project directory. Assuming you have a `prod.env` file in your project directory, you can source from that using the `-e` flag of `nio_run`.
+2. The `.env` files in your project directory. Assuming you have a `prod.env` file in your project directory, you can source from that using the `-e` flag of `niod`.
 
    ```bash
-   $ nio_run -e prod.env
+   $ niod -e prod.env
    ```
 
 In the event that an environment variable is set both at the system level and the local `.env` file level, the system environment variable will take precedence.


### PR DESCRIPTION
As of 01/04/2018 new installations of nio will be run with `niod` instead of `nio_run`