### PR TITLE
Update for adding submodule

### DIFF
--- a/docs/running-nio/docker.md
+++ b/docs/running-nio/docker.md
@@ -12,9 +12,9 @@ git clone https://github.com/niolabs/nio-docker.git nio-docker
 cd nio-docker
 ```
 
-Then update the submodules for the default project
+Then add a submodule for the default project
 ```
-git submodule update --init --recurisve
+git submodule add https://github.com/niolabs/project_template.git default_project
 ```
 
 ---


### PR DESCRIPTION
The nio-docker project instructs users to add a submodule for the default_project. This can be any of our project templates available for running locally. No more need to update a currently installed submodule.