### PR TITLE
APP-694: Remove restricted characters for blocks

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -18,7 +18,7 @@
   * [Raspbian](/installation/rasp.md)
 * [Deploy nio](/deployment/README.md)
 * [System Designer](/system-designer/README.md)
-  * [Reference](/system-designer/designer-tasks.md)
+  * [Reference](/system-designer/reference.md)
   * [Browser Support](/system-designer/browser-support.md)
 
 ---

--- a/docs/blocks/README.md
+++ b/docs/blocks/README.md
@@ -26,6 +26,6 @@ For example, the [_Queue_](https://blocks.n.io/Queue) block exposes a command to
 
 ## See also
 
-* [Blocks in the System Designer](/system-designer/designer-tasks.md#blocks-sd)
+* [Blocks in the System Designer](/system-designer/reference.md#blocks-sd)
 * [Block development](/blocks/block-development/README.md)
 * Glossary—[block](/glossary/README.md#block)

--- a/docs/instances/README.md
+++ b/docs/instances/README.md
@@ -17,5 +17,5 @@ Where you decide to install nio instances (or logic) throughout a system should 
 ---
 ## See also
 
-* [Instances in the System Designer](/system-designer/designer-tasks.md#instance-sd)
+* [Instances in the System Designer](/system-designer/reference.md#instance-sd)
 * Glossary—[instance](/glossary/README.md#instance)

--- a/docs/instances/environment-variables.md
+++ b/docs/instances/environment-variables.md
@@ -6,7 +6,7 @@ The nio Platform allows you to define and use variables when configuring your in
 
 ## Access tokens and other secrets
 
-Often a block will need some sort of access token or password in its configuration. Rather than store those in the block config directly—where they are visible in plain text—we recommend using an environment variable. There are two ways to manage your environment variables. The easiest way is to use the [Instance Editor](/system-designer/designer-tasks.md#instance-env). Alternatively, if you are running an instance locally, you can add environment variables to the `[user_defined]` section at the top of your `nio.conf` configuration file.
+Often a block will need some sort of access token or password in its configuration. Rather than store those in the block config directly—where they are visible in plain text—we recommend using an environment variable. There are two ways to manage your environment variables. The easiest way is to use the [Instance Editor](/system-designer/reference.md#instance-env). Alternatively, if you are running an instance locally, you can add environment variables to the `[user_defined]` section at the top of your `nio.conf` configuration file.
 
 ```
 MY_SECRET=p@$$w0rd

--- a/docs/services/README.md
+++ b/docs/services/README.md
@@ -22,6 +22,6 @@ Services can be started and stopped, and thus have a lifecycle of their own. Typ
 ---
 ## See also
 
-* [Services in the System Designer](/system-designer/designer-tasks.md#service-sd)
+* [Services in the System Designer](/system-designer/reference.md#service-sd)
 * [Service design patterns](/service-design-patterns/)
 * Glossary—[service](/glossary/README.md#service)

--- a/docs/system-designer/reference.md
+++ b/docs/system-designer/reference.md
@@ -206,8 +206,6 @@ In the **block library** search box, enter a block type name.
 > **[info] Block names**
 >
 > In nio versions less than 3.0, block names cannot be edited after creation.
->
-> Block names cannot contain the following characters: `*  |  \ /  :  ”  <> / ?`
 
 ### Block edit, command, delete
 

--- a/docs/systems/README.md
+++ b/docs/systems/README.md
@@ -13,5 +13,5 @@ Building digital distributed systems can be extraordinarily complex.  nio simpli
 ---
 ## See also
 
-* [Systems in the System Designer](/system-designer/designer-tasks.md#system-sd)
+* [Systems in the System Designer](/system-designer/reference.md#system-sd)
 * Glossary—[system](/glossary/README.md#system)

--- a/docs/ui/build-a-ui.md
+++ b/docs/ui/build-a-ui.md
@@ -36,7 +36,7 @@ Follow these steps to create a simple UI that can publish to, subscribe to, and 
 1. Get your Pubkeeper **hostname** and **token** from your nio-managed cloud-instance:
     <img class="right border" src="/img/cloud/editSystem.png" width="250" />
     1. Open the nio **System Designer** in a browser: https://app.n.io/design.
-        1. If you need to create your first system, follow the instructions here: [docs.n.io/system-designer/designer-tasks.html#create-a-system](/system-designer/designer-tasks.md#create-a-system).
+        1. If you need to create your first system, follow the instructions here: [docs.n.io/system-designer/reference.html#create-a-system](/system-designer/reference.md#create-a-system).
     1. Hover over the system card and click the **edit** button in the toolbar that appears to open its configuration.
 1. In `config.js`:
     1. Set `PK_HOST` to your **hostname** value.


### PR DESCRIPTION
I also renamed the `designer-tasks` file to `reference` so that it matched what it said in the nav on the left.