### PR TITLE
link to specific files to prevent relative url failure

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ To access the nio System Designer, sign up for a plan here: <https://niolabs.com
 
 ## How do you want to use nio?
 
-**The quickest way to use nio is [in the cloud](/quickstart).** A nio-managed cloud system does not require any installation and comes with a [Pubkeeper server](/pubkeeper).
+**The quickest way to use nio is [in the cloud](/quickstart/README.md).** A nio-managed cloud system does not require any installation and comes with a [Pubkeeper server](/pubkeeper/README.md).
 
 Most of the time, Pubkeeper runs invisibly in the background. However, for more customizable use cases, you can sign up for a license that includes a downloadable Pubkeeper server.
 
@@ -16,18 +16,18 @@ Here are some example configurations of nio and Pubkeeper ranked from simplest t
 
 | nio Platform | Pubkeeper Server | use case | personal | commercial
 |------| -----|  ----| -----| ----|
-| [cloud](/quickstart) | cloud | [cloud applications](/quickstart) | ✔️ | ✔️ |
-| [local](/installation/nio) | cloud | [distributed applications](/installation/nio) | ✔️ | ✔️ |
-| local | [local](/installation/pubkeeper) | [enterprise applications](https://niolabs.com/enterprise) |  | ✔️ |
+| [cloud](/quickstart/README.md) | cloud | [cloud applications](/quickstart/README.md) | ✔️ | ✔️ |
+| [local](/installation/nio/README.md) | cloud | [distributed applications](/installation/nio/README.md) | ✔️ | ✔️ |
+| local | [local](/installation/pubkeeper/README.md) | [enterprise applications](https://niolabs.com/enterprise) |  | ✔️ |
 
 ---
 
 Follow each link to see instructions for your use case:
 
-* [Cloud Applications](/quickstart):  (_Beginner_)
+* [Cloud Applications](/quickstart/README.md):  (_Beginner_)
   * We run nio for you, and you use the nio System Designer to build cloud-based solutions.
   * **The easiest way to get started quickly**
-* [Distributed Applications](/installation/nio): (_Intermediate_)
+* [Distributed Applications](/installation/nio/README.md): (_Intermediate_)
   * You run nio wherever you want and use the System Designer to build and administer it. 
 * [Enterprise Applications](https://niolabs.com/enterprise): (_Advanced_)
   * You run nio connected to a Pubkeeper server on your local network.


### PR DESCRIPTION
On https://docs.n.io the local install link would not allow you to select an operating system as the URL was incorrectly relative (without a forward `/`)

Linking to specific files should fix that. 